### PR TITLE
fix the different of java source and target name

### DIFF
--- a/nchc/manifests/java/install.pp
+++ b/nchc/manifests/java/install.pp
@@ -22,31 +22,31 @@ class nchc::java::install{
 #        creates => "${java::params::java_base}/jdk${java::params::java_version}.tar.gz",
 #    }
 
-    file { "${nchc::params::java::java_base}/jdk${nchc::params::java::java_version}.tar.gz":
+    file { "${nchc::params::java::java_base}/${nchc::params::java::java_source}":
         mode => 0644,
         ensure => present,
         owner => "root",
         group => "root",
         alias => "java-source-tgz",
         before => Exec["untar-java"],
-        source => "puppet:///modules/nchc/java/tarball/jdk${nchc::params::java::java_version}.tar.gz",
+        source => "puppet:///modules/nchc/java/tarball/${nchc::params::java::java_source}",
         #require => [File["java-base"], Exec["download-java"]],
         require => File["java-base"],
     }
 
-    exec { "untar jdk${nchc::params::java::java_version}.tar.gz":
-        command => "tar xfvz jdk${nchc::params::java::java_version}.tar.gz",
+    exec { "untar ${nchc::params::java::java_source}":
+        command => "tar xfv ${nchc::params::java::java_source} -C ${nchc::params::java::java_base}",
         cwd => "${nchc::params::java::java_base}",
-        creates => "${nchc::params::java::java_base}/jdk${nchc::params::java::java_version}",
+        creates => "${nchc::params::java::java_base}/${nchc::params::java::java_version}",
         alias => "untar-java",
         user => "root",
-        onlyif => "test 0 -eq $(ls -al ${nchc::params::java::java_base}/jdk${nchc::params::java::java_version} | grep -c bin)",
+        onlyif => "test 0 -eq $(ls -al ${nchc::params::java::java_base}/${nchc::params::java::java_version} | grep -c bin)",
         before => File["java-app-dir"],
         path   => ["/bin", "/usr/bin", "/usr/sbin"],
         require => File["java-source-tgz"]
     }
 
-    file { "${nchc::params::java::java_base}/jdk${nchc::params::java::java_version}":
+    file { "${nchc::params::java::java_base}/${nchc::params::java::java_version}":
         ensure => "directory",
         mode => 0644,
         owner => "root",
@@ -55,12 +55,12 @@ class nchc::java::install{
         require => Exec["untar-java"],
     }
 
-    exec{ "chown ${nchc::params::java::java_base}/jdk${nchc::params::java::java_version}  dir":
-        command => "chown root:root -R jdk${nchc::params::java::java_version}",
+    exec{ "chown ${nchc::params::java::java_base}/${nchc::params::java::java_version}  dir":
+        command => "chown root:root -R ${nchc::params::java::java_version}",
         cwd => "${nchc::params::java::java_base}/",
         path   => ["/bin", "/usr/bin", "/usr/sbin"],
         user => "root",
-        onlyif => "test root != $(stat -c %U ${nchc::params::java::java_base}/jdk${nchc::params::java::java_version}/bin)",
+        onlyif => "test root != $(stat -c %U ${nchc::params::java::java_base}/${nchc::params::java::java_version}/bin)",
         require => File["java-app-dir"],
     }
 
@@ -68,7 +68,7 @@ class nchc::java::install{
 
     file { "$nchc::params::java::java_current":
         ensure => 'link',
-        target => "${nchc::params::java::java_base}/jdk${nchc::params::java::java_version}",
+        target => "${nchc::params::java::java_base}/${nchc::params::java::java_version}",
         alias => "java-link",
         require => File["java-app-dir"],
     }

--- a/nchc/manifests/params/java.pp
+++ b/nchc/manifests/params/java.pp
@@ -2,8 +2,11 @@
 
 class nchc::params::java {
 
+        $java_source = $::hostname ? {
+            default	=> "jdk-7u71-linux-x64.tar.gz",
+        }
         $java_version = $::hostname ? {
-            default	=> "1.7.0_51",
+            default	=> "jdk1.7.0_71",
         }
         $java_base = $::hostname ? {
             default     => "/opt/java_version",


### PR DESCRIPTION
the name of java source from oracle download was "jdk-7u71-linux-x64.tar.gz" and contant is $PWD/jdk1.7.0_71.

so add parameter of soure name and replace java_verison as target name.

new tar command is "tar -xvf $source -C $target"
